### PR TITLE
Update pulumi fork and patch

### DIFF
--- a/csharp/src/Google.Protobuf/CodedInputStream.cs
+++ b/csharp/src/Google.Protobuf/CodedInputStream.cs
@@ -80,7 +80,7 @@ namespace Google.Protobuf
         /// </summary>
         private ParserInternalState state;
 
-        internal const int DefaultRecursionLimit = 100;
+        internal const int DefaultRecursionLimit = 1000;
         internal const int DefaultSizeLimit = Int32.MaxValue;
         internal const int BufferSize = 4096;
 

--- a/csharp/src/Google.Protobuf/Google.Protobuf.csproj
+++ b/csharp/src/Google.Protobuf/Google.Protobuf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>C# runtime library for Protocol Buffers - Google's data interchange format.</Description>
+    <Description>Pulumi fork to override DefaultRecursionLimit - C# runtime library for Protocol Buffers - Google's data interchange format.</Description>
     <Copyright>Copyright 2015, Google Inc.</Copyright>
     <AssemblyTitle>Google Protocol Buffers</AssemblyTitle>
     <VersionPrefix>3.20.1</VersionPrefix>
@@ -12,6 +12,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../keys/Google.Protobuf.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <PackageId>Pulumi.Protobuf</PackageId>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>Protocol;Buffers;Binary;Serialization;Format;Google;proto;proto3</PackageTags>
     <PackageReleaseNotes>C# proto3 support</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/protocolbuffers/protobuf</PackageProjectUrl>

--- a/csharp/src/Google.Protobuf/ParseContext.cs
+++ b/csharp/src/Google.Protobuf/ParseContext.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 // Protocol Buffers - Google's data interchange format
 // Copyright 2008 Google Inc.  All rights reserved.
 // https://developers.google.com/protocol-buffers/
@@ -52,7 +52,7 @@ namespace Google.Protobuf
     [SecuritySafeCritical]
     public ref struct ParseContext
     {
-        internal const int DefaultRecursionLimit = 100;
+        internal const int DefaultRecursionLimit = 1000;
         internal const int DefaultSizeLimit = Int32.MaxValue;
 
         internal ReadOnlySpan<byte> buffer;


### PR DESCRIPTION
Updates pulumi fork and "dotnet recursion limit patch" to latest protocolbuffers:
* `main` is now the default branch (FWIW)
* `pulumi` branch is now off `3.20.x` branch (currently version `3.20.1`)

@mikhailshilkov PTAL

PS. this is obviously messy, so more than happy for you to close this pull request and sync the fork and re-apply the patch 😀 